### PR TITLE
Automate releases to WAPM

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,6 @@
 [flake8]
 ignore =
   E501, # line too long
+  E203, # space before ":" is used for readability
   W504  # line break after binary operator
 exclude = ./third_party ./out

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -159,7 +159,7 @@ jobs:
     - uses: actions/setup-python@v1
       with:
         python-version: '3.x'
-    - run: sudo apt-get install ninja-build
+    - run: sudo apt-get install ninja-build binaryen
     - name: wasix
       run: python -m pip install wasix
     - name: mkdir

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -159,7 +159,7 @@ jobs:
     - uses: actions/setup-python@v1
       with:
         python-version: '3.x'
-    - run: sudo apt-get install ninja-build binaryen
+    - run: sudo apt-get install ninja-build binaryen wabt
     - name: wasix
       run: python -m pip install wasix
     - name: mkdir

--- a/.github/workflows/wapm_release.yml
+++ b/.github/workflows/wapm_release.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/setup-python@v1
         with:
           python-version: "3.x"
-      - run: sudo apt-get install ninja-build binaryen
+      - run: sudo apt-get install ninja-build binaryen wabt
       - name: wasix
         run: python -m pip install wasix
       - name: mkdir

--- a/.github/workflows/wapm_release.yml
+++ b/.github/workflows/wapm_release.yml
@@ -1,0 +1,36 @@
+name: WAPM Releases
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+jobs:
+  release-wasm-wasi:
+    name: Publish to WAPM
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+        with:
+          submodules: true
+      - uses: actions/setup-python@v1
+        with:
+          python-version: "3.x"
+      - run: sudo apt-get install ninja-build
+      - name: wasix
+        run: python -m pip install wasix
+      - name: mkdir
+      - name: Setup Wasmer
+        uses: wasmerio/setup-wasmer@v1
+        run: mkdir -p out
+      - name: Configure CMake
+        run: wasix-make cmake .. -DCMAKE_BUILD_TYPE=Release -DWASI=ON
+        working-directory: out
+      - name: Build
+        run: make -j8
+        working-directory: out
+      - name: Publish
+        uses: wasmerio/wapm-publish@v1
+        with:
+          token: ${{ secrets.WAPM_PROD_TOKEN }}

--- a/.github/workflows/wapm_release.yml
+++ b/.github/workflows/wapm_release.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/setup-python@v1
         with:
           python-version: "3.x"
-      - run: sudo apt-get install ninja-build
+      - run: sudo apt-get install ninja-build binaryen
       - name: wasix
         run: python -m pip install wasix
       - name: mkdir

--- a/embeddings/py/input.py
+++ b/embeddings/py/input.py
@@ -1,24 +1,26 @@
-from wasmer import Store, Module, Instance
+from wasmer import Instance
 from intrinsics import encode_utf8, decode_utf8
 from enum import IntFlag
 
-class WasmFeature(IntFlag):
-    Exceptions=1
-    MutableGlobals=2
-    SatFloatToInt=4
-    SignExtension=8
-    SIMD=16
-    Threads=32
-    MultiValue=64
-    TailCall=128
-    BulkMemory=256
-    ReferenceTypes=512
-    Annotations=1024
-    GC=2048
 
-    Phase5=1|2|4|8|16|BulkMemory|ReferenceTypes
-    Phase4=Phase5
-    Phase3=Phase4|MultiValue|TailCall|Annotations
+class WasmFeature(IntFlag):
+    Exceptions = 1
+    MutableGlobals = 2
+    SatFloatToInt = 4
+    SignExtension = 8
+    SIMD = 16
+    Threads = 32
+    MultiValue = 64
+    TailCall = 128
+    BulkMemory = 256
+    ReferenceTypes = 512
+    Annotations = 1024
+    GC = 2048
+
+    Phase5 = 1 | 2 | 4 | 8 | 16 | BulkMemory | ReferenceTypes
+    Phase4 = Phase5
+    Phase3 = Phase4 | MultiValue | TailCall | Annotations
+
 
 class WABT:
     def instantiate(self, module, imports):
@@ -32,7 +34,7 @@ class WABT:
         len0 = len(val0)
         ptr0 = realloc(0, 0, 1, len0 * 1)
         buffer = memory.int8_view()
-        buffer[ptr0:ptr0+len0*1] = val0
+        buffer[ptr0 : ptr0 + len0 * 1] = val0
         ret = self.instance.exports.wasm2wat(ptr0, len0, flags)
         ret = int(ret / 4)
         buf32 = memory.int32_view()
@@ -61,7 +63,7 @@ class WABT:
             ptr1 = buf32[ret + 2]
             len1 = buf32[ret + 4]
             buf8 = memory.int8_view()
-            wasm = bytearray(buf8[ptr1:ptr1+len1])
+            wasm = bytearray(buf8[ptr1 : ptr1 + len1])
             free(ptr1, len1, 1)
             return wasm
         elif buf32[ret] == 1:

--- a/embeddings/py/intrinsics.py
+++ b/embeddings/py/intrinsics.py
@@ -1,18 +1,19 @@
 def encode_utf8(string, realloc, memory):
-    string_bytes = string.encode('utf8')
+    string_bytes = string.encode("utf8")
     string_len = len(string_bytes)
-    ptr = realloc(0, 0, 1, string_len) & 0xffffffff
+    ptr = realloc(0, 0, 1, string_len) & 0xFFFFFFFF
     if ptr + string_len > memory.data_size:
         raise IndexError("The string is out of bounds")
     buffer = memory.int8_view()
-    buffer[ptr:ptr+string_len] = string_bytes
+    buffer[ptr : ptr + string_len] = string_bytes
     return ptr, string_len
 
+
 def decode_utf8(memory, ptr, string_len):
-    ptr = ptr & 0xffffffff 
-    string_len = string_len & 0xffffffff
+    ptr = ptr & 0xFFFFFFFF
+    string_len = string_len & 0xFFFFFFFF
     if ptr + string_len > memory.data_size:
-        raise IndexError('The string is out of bounds')
+        raise IndexError("The string is out of bounds")
     buffer = memory.int8_view()
-    bytes = bytearray(buffer[ptr:ptr+string_len])
-    return bytes.decode('utf8')
+    bytes = bytearray(buffer[ptr : ptr + string_len])
+    return bytes.decode("utf8")

--- a/embeddings/py/test.py
+++ b/embeddings/py/test.py
@@ -1,9 +1,9 @@
-from wasmer import Store, Module, wasi, ImportObject, Function, FunctionType, Type
+from wasmer import Store, Module, wasi
 from input import WABT, WasmFeature
 import os
 
 __dir__ = os.path.dirname(os.path.realpath(__file__))
-contents = open(__dir__ + '/../../out/wasi/Debug/libwabt.wasm', 'rb').read()
+contents = open(__dir__ + "/../../out/wasi/Debug/libwabt.wasm", "rb").read()
 
 store = Store()
 module = Module(store, contents)
@@ -27,7 +27,7 @@ module = Module(store, contents)
 # )
 
 wasi_version = wasi.get_version(module, strict=True)
-wasi_env = wasi.StateBuilder('wasi_test_program').finalize()
+wasi_env = wasi.StateBuilder("wasi_test_program").finalize()
 import_object = wasi_env.generate_import_object(store, wasi_version)
 
 
@@ -43,6 +43,7 @@ def wat2wasm(contents):
     except Exception as e:
         print("error", e)
 
+
 def wasm2wat(contents):
     print(f"trying {contents}")
     try:
@@ -52,11 +53,40 @@ def wasm2wat(contents):
         print("error", e)
 
 
-wat2wasm("(module)");
-wat2wasm("xyz");
-wasm2wat(bytearray([
-    0, 97, 115, 109,   1,   0,   0,   0,   0,
-    8,  4, 110,  97, 109, 101,   2,   1,   0,
-    0,  9,   7, 108, 105, 110, 107, 105, 110,
-  103,  2
-]))
+wat2wasm("(module)")
+wat2wasm("xyz")
+wasm2wat(
+    bytearray(
+        [
+            0,
+            97,
+            115,
+            109,
+            1,
+            0,
+            0,
+            0,
+            0,
+            8,
+            4,
+            110,
+            97,
+            109,
+            101,
+            2,
+            1,
+            0,
+            0,
+            9,
+            7,
+            108,
+            105,
+            110,
+            107,
+            105,
+            110,
+            103,
+            2,
+        ]
+    )
+)


### PR DESCRIPTION
This adds a CI job that will automatically publish binaries to WAPM whenever you push up a `v*` tag (i.e. `v1.2.3`).

I'm not an admin so I can't tell whether our `WAPM_PROD_TOKEN` secret is available on this repo. @syrusakbary, can you check?